### PR TITLE
feat : 특정 디렉토리의 파일 이름 불러오는 기능 추가

### DIFF
--- a/utility/fileIO.cpp
+++ b/utility/fileIO.cpp
@@ -1,0 +1,17 @@
+//
+// Created by u-keun song on 2024. 8. 4..
+//
+#include "fileIO.h"
+#include <filesystem>
+
+vector<string> readFileNames(const string& directoryPath) {
+    vector<string> fileNames;
+
+    for (const auto& file : filesystem::directory_iterator(directoryPath)) {
+        if (filesystem::is_regular_file(file.status())) {
+            fileNames.push_back(file.path().filename().string());
+        }
+    }
+
+    return fileNames;
+}

--- a/utility/fileIO.h
+++ b/utility/fileIO.h
@@ -14,7 +14,7 @@
 using namespace std;
 
 template <class T>
-unique_ptr< vector< vector<T> > > readFile(string filePath, char delimiter) {
+unique_ptr< vector< vector<T> > > readFile(string& filePath, char delimiter) {
     ifstream fin;
     fin.open(filePath);
 
@@ -23,7 +23,6 @@ unique_ptr< vector< vector<T> > > readFile(string filePath, char delimiter) {
     auto result = make_unique< vector< vector<T> > >();
 
     string line, token;
-    int idx = 0;
     while (getline(fin, line)) {
         stringstream lineStream(line);
         vector<T> row;
@@ -47,7 +46,7 @@ unique_ptr< vector< vector<T> > > readFile(string filePath, char delimiter) {
 }
 
 template <class T>
-void writeFile(string filePath, char delimiter, vector< vector<T> > data) {
+void writeFile(string& filePath, char delimiter, vector< vector<T> > data) {
     ofstream fout(filePath);
 
     if (!fout) throw runtime_error("Error opening file for writing.\n");
@@ -61,5 +60,7 @@ void writeFile(string filePath, char delimiter, vector< vector<T> > data) {
 
     fout.close();
 }
+
+vector<string> readFileNames(const string& directoryPath);
 
 #endif // FILEIO_H


### PR DESCRIPTION
## Summary

readFileNames() 함수 추가

## Description

<!-- 상세 내용 작성 -->

특정 디렉토리 경로 문자열을 전달해서 그 디렉토리의 파일 이름을 읽어오는 함수를 추가했습니다. 아래의 테스트 코드를 통해 잘 작동하는지 확인해보았습니다. Window, Mac 환경에서 `filesystem`이라는 파일만 포함시키면 모두 사용할 수 있습니다.(`filesystem`은 `fileIO.cpp`에 포함해뒀고, C++17 표준입니다.)
```C++
int main() {

    std::string path = "../test_directory";  // 테스트용 디렉토리 설정
    std::vector<std::string> files = readFileNames(path);

    for (const auto& file : files) {
        std::cout << file << std::endl;
    }

    return 0;
}
```